### PR TITLE
Stop using deprecated pipe coreToLocaleString

### DIFF
--- a/templates/mobile_view_issues_latest.mustache
+++ b/templates/mobile_view_issues_latest.mustache
@@ -3,7 +3,7 @@
     <ion-list>
         <ion-item>
             <ion-label>
-                <p class="item-heading">{{ <%timecreated%> | coreToLocaleString }}</p>
+                <p class="item-heading">{{ <%timecreated%> * 1000 | coreFormatDate }}</p>
                 <p><%grade%></p>
             </ion-label>
         </ion-item>


### PR DESCRIPTION
This pipe has been deprecated for a while and will be removed in a near future, breaking the plugin if it still uses it.